### PR TITLE
crystal_structureはやめて、method=automatic & lattice_systemを使いましょう

### DIFF
--- a/wsl/Fe/band/nfinp.data
+++ b/wsl/Fe/band/nfinp.data
@@ -21,7 +21,10 @@ structure{
   }
   magnetic_state = ferro
   symmetry{
-    crystal_structure = bcc
+    method = automatic
+    tspace{
+      lattice_system = bodycentered
+    }
   }
   atom_list{
     coordinate_system = internal

--- a/wsl/Fe/dos/nfinp.data
+++ b/wsl/Fe/dos/nfinp.data
@@ -24,7 +24,10 @@ structure{
      alpha = 90, beta = 90, gamma = 90
    }
   symmetry{
-       crystal_structure = bcc
+    method = automatic
+    tspace{
+      lattice_system = bodycentered
+    }
   }
   magnetic_state  = ferro   !{para|af|ferro}
   atom_list{

--- a/wsl/Si2/eps/nfinp.data
+++ b/wsl/Si2/eps/nfinp.data
@@ -24,7 +24,10 @@ structure{
       c_vector =  5.1300000000        5.1300000000        0.0000000000
     }
     symmetry{
-      crystal_structure = diamond
+       method = automatic
+       tspace{
+         lattice_system = facecentered
+       }
     }
     atom_list{
        atoms{


### PR DESCRIPTION
`crystal_structure`は汎用性が低いのでやめた方が良いと思います。

また、対称性指定は、SCF計算のそれと同じにした方が、わかりやすいと思います。